### PR TITLE
Small quality of life fixes

### DIFF
--- a/brix/classes.py
+++ b/brix/classes.py
@@ -9,7 +9,7 @@ import geopandas as gpd
 import hashlib
 import weakref
 from warnings import warn
-from time import sleep, time
+from time import sleep, time as right_now
 from collections import defaultdict
 from .helpers import is_number, get_buffer_size, urljoin, get_timezone_offset
 from threading import Thread
@@ -346,7 +346,7 @@ class Handler(Thread):
 	table_name : str
 		Table name to lisen to.
 		https://cityio.media.mit.edu/api/table/table_name
-	quietly : boolean, defaults to `True`
+	quietly : boolean, defaults to `False`
 		If True, it will show the status of every API call.
 	host_mode : str, defaults to 'remote'
 		If 'local' it will use http://127.0.0.1:5000/ as host.
@@ -384,7 +384,7 @@ class Handler(Thread):
 		self.sleep_time_short = 0.5
 		self.sleep_time_long  = 2
 		self.rest_mode   = False
-		self.active_start = time.time()
+		self.active_start = right_now()
 		self.total_active_time  = 5*60
 
 		self.nAttempts = 5
@@ -440,19 +440,22 @@ class Handler(Thread):
 		'''
 		Turns off rest mode.
 		'''
+		if not self.quietly:
+			print('Waking up!')
 		self.rest_mode = False
-		self.active_start = time.time()
+		self.active_start = right_now()
 
 	def check_rest(self):
 		'''
 		Checks if module should be put in resting mode
 		'''
-		current_time = time.time()
-		if current_time-self.active_start>=self.total_active_time:
-			if not self.quietly:
-				print('Going into rest mode')
-				print('Time active:',current_time-self.active_start)
-			self.rest_mode = True
+		if not self.rest_mode:
+			current_time = right_now()
+			if current_time-self.active_start>=self.total_active_time:
+				if not self.quietly:
+					print('Going into rest mode')
+					print('Time active:',current_time-self.active_start)
+				self.rest_mode = True
 
 	def grid_bounds(self,bbox=False,buffer_percent=None):
 		'''
@@ -1408,7 +1411,7 @@ class Handler(Thread):
 			print('Cleared table')
 		self.grid_hash_id = grid_hash_id
 
-	def _listen(self,showFront=True,robust=False):
+	def _listen(self,showFront=False,robust=False):
 		'''
 		Lower level listen. Should only be called directly for debugging purposes. 
 		Use :func:`brix.Handler.listen` instead.
@@ -1419,7 +1422,7 @@ class Handler(Thread):
 
 		Parameters
 		----------
-		showFront : boolean, defaults to `True`
+		showFront : boolean, defaults to `False`
 			If `True` it will open the front-end URL in a webbrowser at start.
 		robust : boolean, defaults to `False`
 			If `True`, whenever a grid configuration breaks an indicator, the module will not stop, but rather wait until the grid changes and try to update again.
@@ -1467,7 +1470,7 @@ class Handler(Thread):
 		'''
 		self._listen(showFront=False)
 
-	def listen(self,new_thread=False,showFront=True,append=False,clear_endpoints=False,robust=False):
+	def listen(self,new_thread=False,showFront=False,append=False,clear_endpoints=False,robust=False):
 		'''
 		Listens for changes in the table's geogrid and update all indicators accordingly. 
 		You can use the update_package method to see the object that will be posted to the table.
@@ -1480,7 +1483,7 @@ class Handler(Thread):
 		new_thread : boolean, defaults to `False`.
 			If `True` it will run in a separate thread, freeing up the main thread for other tables.
 			We recommend setting this to `False` when debugging, to avoid needing to recreate the object. 
-		showFront : boolean, defaults to `True`
+		showFront : boolean, defaults to `False`
 			If `True` it will open the front-end URL in a webbrowser at start.
 			Only works if `new_tread=False`.
 		append : boolean, defaults to `False`

--- a/brix/classes.py
+++ b/brix/classes.py
@@ -459,6 +459,18 @@ class Handler(Thread):
 			if not self.quietly:
 				print('Timezone set to:',hour_offset)
 
+	def center_grid_view(self):
+		'''
+		Sets the initial grid view to the center of the grid. 
+		'''
+		grid_center = self.grid_bounds().centroid
+		lon = grid_center.x
+		lat = grid_center.y
+		lat_url = urljoin(self.cityIO_GEOGRID_post_url,'properties','header','latitude')
+		lon_url = urljoin(self.cityIO_GEOGRID_post_url,'properties','header','longitude')
+		r = requests.post(lat_url,data=str(lat),headers=self.post_headers)
+		r = requests.post(lon_url,data=str(lon),headers=self.post_headers)
+
 	def check_table(self,return_value=False):
 		'''Prints the front end url for the table. 
 
@@ -1408,10 +1420,9 @@ class Handler(Thread):
 							grid_hash_id = self.get_grid_hash()
 						self.perform_update(grid_hash_id=grid_hash_id,append=self.append_on_post)
 					except Exception:
-						if not self.quietly:
-							print('I was not able to update grid with hash:',grid_hash_id)
-							print(traceback.format_exc())
-							print('Waiting until a new grid appears')
+						warn('I was not able to update grid with hash:',grid_hash_id)
+						warn(traceback.format_exc())
+						warn('Waiting until a new grid appears')
 						self.grid_hash_id = grid_hash_id
 
 	def run(self):

--- a/brix/classes.py
+++ b/brix/classes.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 try:
 	import networkx as nx
 except:
-	warn('Networkx no found.')
+	warn('Networkx not found.')
 import traceback
 
 class GEOGRIDDATA(list):

--- a/brix/classes.py
+++ b/brix/classes.py
@@ -445,32 +445,6 @@ class Handler(Thread):
 		bounds = geogrid_data.bounds(bbox=bbox,buffer_percent=buffer_percent)
 		return bounds
 
-	def set_timezone(self):
-		'''
-		Sets the time zone of the table based on its coordinates.
-		Useful for front end shadow simulation. 
-		'''
-		props = self.get_table_properties()
-		lat,lon = props['latitude'],props['longitude']
-		hour_offset = get_timezone_offset(lat,lon)
-		url = urljoin(self.cityIO_post_url,'GEOGRID','properties','header','tz')
-		r = requests.post(url,data=str(int(hour_offset)),headers=self.post_headers)
-		if r.status_code==200:
-			if not self.quietly:
-				print('Timezone set to:',hour_offset)
-
-	def center_grid_view(self):
-		'''
-		Sets the initial grid view to the center of the grid. 
-		'''
-		grid_center = self.grid_bounds().centroid
-		lon = grid_center.x
-		lat = grid_center.y
-		lat_url = urljoin(self.cityIO_GEOGRID_post_url,'properties','header','latitude')
-		lon_url = urljoin(self.cityIO_GEOGRID_post_url,'properties','header','longitude')
-		r = requests.post(lat_url,data=str(lat),headers=self.post_headers)
-		r = requests.post(lon_url,data=str(lon),headers=self.post_headers)
-
 	def check_table(self,return_value=False):
 		'''Prints the front end url for the table. 
 
@@ -562,6 +536,32 @@ class Handler(Thread):
 			if obj.name not in self.list_indicators():
 				unlinked_indicators.append(obj.name)
 		return unlinked_indicators
+
+	def set_timezone(self):
+		'''
+		Sets the time zone of the table based on its coordinates.
+		Useful for front end shadow simulation. 
+		'''
+		props = self.get_table_properties()
+		lat,lon = props['latitude'],props['longitude']
+		hour_offset = get_timezone_offset(lat,lon)
+		url = urljoin(self.cityIO_post_url,'GEOGRID','properties','header','tz')
+		r = requests.post(url,data=str(int(hour_offset)),headers=self.post_headers)
+		if r.status_code==200:
+			if not self.quietly:
+				print('Timezone set to:',hour_offset)
+
+	def center_grid_view(self):
+		'''
+		Sets the initial grid view to the center of the grid. 
+		'''
+		grid_center = self.grid_bounds().centroid
+		lon = grid_center.x
+		lat = grid_center.y
+		lat_url = urljoin(self.cityIO_GEOGRID_post_url,'properties','header','latitude')
+		lon_url = urljoin(self.cityIO_GEOGRID_post_url,'properties','header','longitude')
+		r = requests.post(lat_url,data=str(lat),headers=self.post_headers)
+		r = requests.post(lon_url,data=str(lon),headers=self.post_headers)
 
 	def indicator(self,name):
 		'''Returns the :class:`brix.Indicator` with the given name.

--- a/brix/classes.py
+++ b/brix/classes.py
@@ -476,12 +476,8 @@ class Handler(Thread):
 			Current value of selected indicators.
 		'''
 		if indicator_type in ['numeric']:
-			if not self.quietly:
-				print(self.cityIO_get_url+'/indicators')
 			r = self._get_url(urljoin(self.cityIO_get_url,'indicators'))
 		elif indicator_type in ['heatmap','access']:
-			if not self.quietly:
-				print(self.cityIO_get_url+'/access')
 			r = self._get_url(urljoin(self.cityIO_get_url,'access'))
 		else:
 			raise NameError('Indicator type should either be numeric, heatmap, or access. Current type: '+str(indicator_type))
@@ -1256,7 +1252,7 @@ class Handler(Thread):
 		geogrid_data = self._get_grid_data(include_geometries=include_geometries,with_properties=with_properties)
 		return geogrid_data
 
-	def perform_update(self,grid_hash_id=None,append=False):
+	def perform_update(self,grid_hash_id=None,append=False,return_update_package=False):
 		'''
 		Performs single table update.
 
@@ -1266,6 +1262,8 @@ class Handler(Thread):
 			Current grid hash id. If not provided, it will retrieve it.
 		append : boolean, defaults to `True`
 			If `True`, it will append the new indicators to whatever is already there.
+		return_update_package : boolean, defaults to `False`
+			If `True` this funciton will return the posted object.
 		'''
 		if grid_hash_id is None: 
 			grid_hash_id = self.get_grid_hash()	
@@ -1292,6 +1290,8 @@ class Handler(Thread):
 		self.grid_hash_id = grid_hash_id
 		if not self.quietly:
 			print('Local grid hash:',grid_hash_id)
+		if return_update_package:
+			return new_values
 
 	def _post_indicators(self,new_values,post_empty=False):
 		'''

--- a/brix/classes.py
+++ b/brix/classes.py
@@ -19,7 +19,8 @@ from copy import deepcopy
 try:
 	import networkx as nx
 except:
-	print('Warning: networkx no found.')
+	warn('Networkx no found.')
+import traceback
 
 class GEOGRIDDATA(list):
 	'''
@@ -989,8 +990,9 @@ class Handler(Thread):
 					pass
 				else:
 					raise NameError(f'Unrecognized indicator type {I.indicator_type} for {indicator_name}')
-			except:
+			except Exception:
 				warn('Indicator not working:'+str(indicator_name))
+				warn(traceback.format_exc())
 
 		# Get values for composite indicators
 		for indicator_name in self.indicators:
@@ -1405,10 +1407,10 @@ class Handler(Thread):
 						if self.perform_geogrid_data_update():
 							grid_hash_id = self.get_grid_hash()
 						self.perform_update(grid_hash_id=grid_hash_id,append=self.append_on_post)
-					except Exception as e:
+					except Exception:
 						if not self.quietly:
 							print('I was not able to update grid with hash:',grid_hash_id)
-							print(e)
+							print(traceback.format_exc())
 							print('Waiting until a new grid appears')
 						self.grid_hash_id = grid_hash_id
 

--- a/brix/helpers.py
+++ b/brix/helpers.py
@@ -2,6 +2,7 @@
 import json
 import geopandas as gpd
 from datetime import datetime
+from warnings import warn
 try:
 	from timezonefinder import TimezoneFinder
 	from pytz import timezone, utc

--- a/brix/helpers.py
+++ b/brix/helpers.py
@@ -1,13 +1,12 @@
 # Helper functions live here
 import json
 import geopandas as gpd
-
-try: # libraries needed to set the timezone of the table
-	from datetime import datetime
+from datetime import datetime
+try:
 	from timezonefinder import TimezoneFinder
 	from pytz import timezone, utc
 except:
-	pass
+	warn('timezonefinder and pytz not found')
 
 def urljoin(*args,trailing_slash=True):
 	trailing_slash_char = '/' if trailing_slash else ''

--- a/test/test_classes.py
+++ b/test/test_classes.py
@@ -35,6 +35,7 @@ class TestHandler(unittest.TestCase):
 		'''
 		for table_name in self.table_list:
 			H = Handler(table_name)
+			H.clear_endpoints()
 			geogrid_data = H.get_geogrid_data()
 
 			indicator_list = []
@@ -100,6 +101,7 @@ class TestHandler(unittest.TestCase):
 	def test_table_update(self):
 		for table_name in self.table_list:
 			H = Handler(table_name)
+			H.clear_endpoints()
 			indicator_list = []
 			rand = RandomIndicator()
 			indicator_list.append(rand)

--- a/test/test_classes.py
+++ b/test/test_classes.py
@@ -17,8 +17,17 @@ class TestHandler(unittest.TestCase):
 		for table_name in self.table_list:
 			H = Handler(table_name)
 			cityIO_get_url = H.cityIO_get_url.strip('/')
-			hashes = requests.get(f'{cityIO_get_url}/meta/hashes').json()
+			hashes = requests.get(f'{cityIO_get_url}/meta/hashes/').json()
 			self.assertEqual(H.get_grid_hash(),hashes['GEOGRIDDATA'])
+
+	def compare_numeric(self,i_list,j_list):
+		'''
+		Compares two lists of numeric indicators
+		'''
+		for i in i_list:
+			for j in j_list:
+				if i['name']==j['name']:
+					self.assertEqual(i,j)
 
 	def test_update_package_numeric(self):
 		'''
@@ -60,6 +69,9 @@ class TestHandler(unittest.TestCase):
 				self.assertIn(name,package_names)
 
 	def test_user(self):
+		'''
+		Tests that Handler is updating its hash.
+		'''
 		for table_name in self.table_list:
 			U = User(table_name)
 			U.start_user()
@@ -84,6 +96,21 @@ class TestHandler(unittest.TestCase):
 				self.assertIn('features',   heatmap_keys)
 				self.assertIn('properties', heatmap_keys)
 				self.assertIn('type',       heatmap_keys)
+
+	def test_table_update(self):
+		for table_name in self.table_list:
+			H = Handler(table_name)
+			indicator_list = []
+			rand = RandomIndicator()
+			indicator_list.append(rand)
+			shell = ShellIndicator()
+			indicator_list.append(shell)
+			div = Diversity()
+			indicator_list.append(div)
+			H.add_indicators(indicator_list)
+			update_package  = H.perform_update(return_update_package=True)
+			current_numeric = H.see_current(indicator_type='numeric')
+			self.compare_numeric(update_package['numeric'],current_numeric)
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Few additional features:
1. Function to move the initial view to center of the grid (it always bothered me that it starts in the upper right corner)
2. Handler defaults to `quietly=False` as this is how most people use ti anyways
3. Robust mode in `listen` that will not halt runtime when a grid configuration breaks an indicator.
4. Improved testing scripts.
5. Set showFront to default to False
6. Implemented a low frequency `resting` mode that will trigger after 5 minutes of no changes in grid. Will lower the frequency of get grid hash from 2 gets a second to one every two seconds. 