### PR TITLE
Grid maker c

### DIFF
--- a/brix/__init__.py
+++ b/brix/__init__.py
@@ -2,4 +2,4 @@
 from .classes import *
 from .functions import *
 from .test_tools import User, spin_users, stop_users, list_users
-from .grid_maker import Grid, commit_grid, edit_types
+from .grid_maker import Grid

--- a/brix/classes.py
+++ b/brix/classes.py
@@ -420,7 +420,16 @@ class Handler(Thread):
 		self.indicators = {}
 		self.update_geogrid_data_functions = []
 		self.grid_hash_id = None
-		if not shell_mode:
+
+		self.shell_mode = shell_mode
+
+		if not self.shell_mode:
+			if not self.is_table():
+				if not self.quietly:
+					print('Table does not exist, setting Handler to shell_mode')
+				warn('Table does not exist, setting Handler to shell_mode')
+				self.shell_mode = True
+		if not self.shell_mode:
 			self.grid_hash_id = self.get_grid_hash()
 
 		self.previous_indicators = None
@@ -433,6 +442,43 @@ class Handler(Thread):
 		self.classification_list = ['LBCS','NAICS']
 
 		self.OSM_data = {}
+
+	def is_table(self):
+		'''
+		Checks it table exists by getting the base url
+
+		Returns
+		-------
+		self.is_table : boolean
+			True if table exists.
+		'''
+		r = self._get_url(self.cityIO_get_url)
+		if r.status_code==200:
+			return True
+		else:
+			return = False
+
+	def delete_table(self):
+		'''
+		Deletes table if it exists.
+		Will prompt user to make sure this function was not run by mistake.
+		'''
+		if self.is_table():
+			delete_table = input(f'Are you sure you want to delete {self.table_name}?')
+			delete_table = (delete_table.lower().strip()[0] == 'y')
+			if delete_table:
+				r = requests.delete(self.cityIO_post_url)
+				if r.status_code==200:
+					if not self.quietly:
+						print(f'{self.table_name} deleted')
+					self.is_table = None
+				else:
+					warn(f'Something went wrong, status_code:{r.status_code}')
+			else:
+				if not self.quietly:
+					print('Table not deleted')
+		else:
+			print('Table does not exist')
 
 	def sleep_time(self):
 		'''

--- a/brix/classes.py
+++ b/brix/classes.py
@@ -456,7 +456,7 @@ class Handler(Thread):
 		if r.status_code==200:
 			return True
 		else:
-			return = False
+			return False
 
 	def delete_table(self):
 		'''

--- a/brix/grid_maker.py
+++ b/brix/grid_maker.py
@@ -249,7 +249,7 @@ class Grid(Handler):
             if not self.quietly:
                 print("Table not overwritten")
 
-    def edit_types(types_json):
+    def edit_types(self,types_json):
         '''
         Changes the default types for user defined types.
         If the GEOGRID object returned has not been created, it will created using the default properties.

--- a/brix/grid_maker.py
+++ b/brix/grid_maker.py
@@ -22,38 +22,37 @@ import traceback
 from warnings import warn
 
 class Grid(Handler):
+    """
+    Takes the properties of the grid and using the Haversine formula, 
+    computes the location of the top-right corner. Then projects
+    to spatial coordinates in order to find the locations of the rest of 
+    the grid cells
+
+    Parameters
+    ----------
+    table_name: str
+        Name of table to create.
+        It will overwrite it if it exists.
+    top_left_lat: float
+        Latitude of top left corner of grid
+    top_left_lon: float
+        Longitude of top left corner of grid
+    cell_size: float, defaults to 100
+        Lenght in meters of the side of each cell.
+    nrows: int, defaults to 20
+        Number of rows
+    ncols: int, defaults to 20
+        Number of columns
+    rotation: int, defaults to 0
+        Roation of the grid.
+    crs_epsg: str
+        EPSG code for the desired projection.
+        Do not include 'EPSG'
+        if crs_epsg== None, the projection will be estimated based on the longitude
+    """
     wgs=pyproj.Proj("EPSG:4326")
     def __init__(self, table_name, top_left_lat, top_left_lon, 
                  cell_size=100, nrows=20, ncols=20, rotation=0, crs_epsg=None ,quietly=False):
-        """
-        Takes the properties of the grid and using the Haversine formula, 
-        computes the location of the top-right corner. Then projects
-        to spatial coordinates in order to find the locations of the rest of 
-        the grid cells
-
-        Parameters
-        ----------
-        table_name: str
-            Name of table to create.
-            It will overwrite it if it exists.
-        top_left_lat: float
-            Latitude of top left corner of grid
-        top_left_lon: float
-            Longitude of top left corner of grid
-        cell_size: float, defaults to 100
-            Lenght in meters of the side of each cell.
-        nrows: int, defaults to 20
-            Number of rows
-        ncols: int, defaults to 20
-            Number of columns
-        rotation: int, defaults to 0
-            Roation of the grid.
-        crs_epsg: str
-            EPSG code for the desired projection.
-            Do not include 'EPSG'
-            if crs_epsg== None, the projection will be estimated based on the longitude
-        """
-        
         if not check_table_name(table_name):
             new_table_name = normalize_table_name(table_name)
             if not quietly:

--- a/brix/grid_maker.py
+++ b/brix/grid_maker.py
@@ -7,7 +7,7 @@ Created on Mon Jul 29 18:57:59 2019
 @contributors: crisjf, guadalupebabio
 """
 from .classes import Handler
-from .helpers import deg_to_rad,rad_to_deg
+from .helpers import deg_to_rad,rad_to_deg, get_timezone_offset
 from .functions import normalize_table_name, check_table_name
 
 import pyproj
@@ -18,12 +18,13 @@ import requests
 import matplotlib.pyplot as plt
 import copy
 import json
+import traceback
 from warnings import warn
 
-class Grid():
+class Grid(Handler):
     wgs=pyproj.Proj("EPSG:4326")
-    def __init__(self, table_name, top_left_lon, top_left_lat, rotation, 
-                 cell_size, nrows, ncols, flip_y=False, crs_epsg=None):
+    def __init__(self, table_name, top_left_lat, top_left_lon, 
+                 cell_size=100, nrows=20, ncols=20, rotation=0, crs_epsg=None ,quietly=False):
         """
         Takes the properties of the grid and using the Haversine formula, 
         computes the location of the top-right corner. Then projects
@@ -32,16 +33,31 @@ class Grid():
 
         Parameters
         ----------
+        table_name: str
+            Name of table to create.
+            It will overwrite it if it exists.
+        top_left_lat: float
+            Latitude of top left corner of grid
+        top_left_lon: float
+            Longitude of top left corner of grid
+        cell_size: float, defaults to 100
+            Lenght in meters of the side of each cell.
+        nrows: int, defaults to 20
+            Number of rows
+        ncols: int, defaults to 20
+            Number of columns
+        rotation: int, defaults to 0
+            Roation of the grid.
         crs_epsg: str
             EPSG code for the desired projection.
             Do not include 'EPSG'
             if crs_epsg== None, the projection will be estimated based on the longitude
-
-
         """
+        
         if not check_table_name(table_name):
             new_table_name = normalize_table_name(table_name)
-            print(f'Incorrect table name "{table_name}", using "{new_table_name}" instead')
+            if not quietly:
+                print(f'Incorrect table name "{table_name}", using "{new_table_name}" instead')
             warn(f'Incorrect table name "{table_name}", using "{new_table_name}" instead')
             table_name = new_table_name
 
@@ -51,6 +67,19 @@ class Grid():
         else:
             crs = f"EPSG:{crs_epsg}"
 
+        super(Grid, self).__init__(
+                table_name, 
+                quietly = quietly, 
+                shell_mode = True
+        )
+
+        if self.is_table():
+            if not self.quietly:
+                print(f'Table {self.table_name} already exists')
+            warn(f'Table {self.table_name} already exists')
+
+        if not self.quietly:
+            print('Calculating initial coordinates of each cell')
         EARTH_RADIUS_M=6.371e6
         top_left_lon_lat={'lon': top_left_lon, 'lat': top_left_lat}
         bearing=(90-rotation+360)%360
@@ -85,6 +114,9 @@ class Grid():
         x_rot_trans=[top_left_xy[0]+x_rot[i] for i in range(len(x_rot))]
         y_rot_trans=[top_left_xy[1]+y_rot[i] for i in range(len(x_rot))]
         lat_grid, lon_grid=pyproj.transform(self.projection,self.wgs,x_rot_trans, y_rot_trans)
+
+        if not self.quietly:
+            print('Defining properties and headers')
         self.grid_coords_ll=[[lon_grid[i], lat_grid[i]] for i in range(len(lon_grid))]
         self.grid_coords_xy=[[x_rot_trans[i], y_rot_trans[i]] for i in range(len(y_rot_trans))]
         self.properties={'color':[0,0,0],
@@ -92,21 +124,46 @@ class Grid():
                         'id': 0, 
                         'interactive': "Web",
                         'name': "test"}
-        self.header={'cellSize': cell_size,
+        try:
+            tz = get_timezone_offset(top_left_lat,top_left_lon)
+        except Exception:
+            warn('Could not set timezone.')
+            warn(traceback.format_exc())
+            tz = -5
+        self.header={
+            'cellSize': cell_size,
             'latitude': top_left_lat,
             'longitude': top_left_lon,
-            'ncols':ncols,
+            'ncols': ncols,
             'nrows': nrows,
             'projection': '+proj=lcc +lat_1=42.68333333333333 +lat_2=41.71666666666667 +lat_0=41 +lon_0=-71.5 +x_0=200000 +y_0=750000 +ellps=GRS80 +datum=NAD83 +units=m +no_def', #not sure from where?
             'rotation': rotation,
-            'tableName':table_name,
-            'tz': -5 
-            }
+            'tableName':self.table_name,
+            'tz': tz
+        }
+        self.geojson_object = None
 
-    def get_grid_geojson(self, add_properties={}, include_global_properties=True):
+    def get_grid_geojson(self):
         '''
-        Takes the pre-computed locations of the top-left corner of every grid cell
-        and creates a corresponding Multi-Polygon geojson object
+        Returns the object created with :func:`brix.Grid.set_grid_geojson`.
+        If the object has not been created, it will created using the default properties.
+
+        Returns
+        -------
+        geogrid: dict
+            Object to be posted to GEOGRID endpoint to create table. 
+            See :func:`brix.commit_grid`
+        '''
+        if self.geojson_object is None:
+            self.set_grid_geojson()
+        return self.geojson_object
+
+    def set_grid_geojson(self, add_properties={}, include_global_properties=True):
+        '''
+        Takes the pre-computed locations of the top-left corner of every grid cell and creates a corresponding Multi-Polygon geojson object.
+        Does not return the object, but saves it in object.
+        Use :func:`brix.Grid.get_grid_geojson` to access it
+
 
         Parameters
         ----------
@@ -115,19 +172,14 @@ class Grid():
             Currently not supported
         include_global_properties: Boolean, defaults to `True`
             If `True` it will add global properties to each cell. 
-
-        Returns
-        -------
-        geogrid: dict
-            Object to be posted to GEOGRID endpoint to create table. 
-            See :func:`brix.commit_grid`
         '''
+        if not self.quietly:
+            print('Generating grid geojson')
         dLLdCol=[self.grid_coords_ll[1][0]-self.grid_coords_ll[0][0], 
                          self.grid_coords_ll[1][1]-self.grid_coords_ll[0][1]]
         dLLdRow=[self.grid_coords_ll[self.ncols][0]-self.grid_coords_ll[0][0], 
                        self.grid_coords_ll[self.ncols][1]-self.grid_coords_ll[0][1]]
-        features=[]      
-        print(self.grid_coords_ll) 
+        features=[]
         for i, g in enumerate(self.grid_coords_ll):
             coords=[g, 
                     [g[0]+dLLdRow[0], g[1]+dLLdRow[1]],
@@ -136,7 +188,6 @@ class Grid():
                     [g[0]+dLLdCol[0],g[1]+dLLdCol[1]], 
                     g]
             properties={}
-            print(self.properties)
             properties=copy.copy(self.properties)
             properties['id'] = i
             # for p in self.properties:
@@ -163,7 +214,7 @@ class Grid():
                 'header': self.header,
                 'types' : {'Default': type_attributes}
                 }
-        return geojson_object
+        self.geojson_object = geojson_object
     
     def plot(self):
         '''
@@ -173,45 +224,43 @@ class Grid():
         '''
         plt.scatter([g[0] for g in self.grid_coords_ll], 
             [g[1] for g in self.grid_coords_ll], c='blue', alpha=0.5)
-
         plt.show()
 
-def commit_grid(table_name, geogrid):
-    '''
-    Commits the geogrid to create the new table.
-    This will reset GEOGRIDDATA and clear all indicator endpoints if the table alread existed.
-    
-    Parameters
-    ----------
-    table_name: str
-        Name of table to create.
-    geogrid: dict
-        GEOGRID object returned by :func:`brix.Grid.get_grid_geojson`
-    '''
-    if not check_table_name(table_name):
-        new_table_name = normalize_table_name(table_name)
-        print(f'Incorrect table name "{table_name}", using "{new_table_name}" instead')
-        warn(f'Incorrect table name "{table_name}", using "{new_table_name}" instead')
-        table_name = new_table_name
-    H = Handler(table_name, shell_mode=True)
-    r = requests.post(H.cityIO_post_url, data = json.dumps({'GEOGRID':geogrid}), headers=Handler.cityio_post_headers)
-    print('Geogrid posted to:')
-    print(r.url)
-    print(r.status_code)
-    H.reset_geogrid_data()
-    H.clear_endpoints()
+    def commit_grid(self):
+        '''
+        Commits the geogrid to create the new table.
+        This will reset GEOGRIDDATA and clear all indicator endpoints if the table alread existed.
+        '''
+        post_table = True
+        if self.is_table():
+            post_table = input('Table exists, do you want to overwrite it?')
+            post_table = (post_table.lower().strip()[0]=='y')
+        if post_table:
+            geogrid = self.get_grid_geojson()
+            r = requests.post(self.cityIO_post_url, data = json.dumps({'GEOGRID':geogrid}), headers=self.post_headers)
+            if not self.quietly:
+                print('Geogrid posted to:')
+                print(r.url)
+                print(r.status_code)
+            self.reset_geogrid_data()
+            self.clear_endpoints()
+            if not self.quietly:
+                print(self.front_end_url)
+        else:
+            if not self.quietly:
+                print("Table not overwritten")
 
+    def edit_types(types_json):
+        '''
+        Changes the default types for user defined types.
+        If the GEOGRID object returned has not been created, it will created using the default properties.
 
-def edit_types(geogrid, types_json):
-    '''
-    Changes the default types for user defined types.
-
-    Parameters
-    ----------
-    geogrid: dict
-        GEOGRID object returned by :func:`brix.Grid.get_grid_geojson`
-    types_json: dict
-        Object with new type definitions.
-        Each type name is passed as a key and values are dicts with the properties of each type. 
-    '''
-    geogrid['properties']['types']=types_json
+        Parameters
+        ----------
+        types_json: dict
+            Object with new type definitions.
+            Each type name is passed as a key and values are dicts with the properties of each type. 
+        '''
+        if self.geojson_object is None:
+            self.set_grid_geojson()
+        self.geojson_object['properties']['types']=types_json


### PR DESCRIPTION
This update will break any code that was using this branch.

Updates are:
1. Made `Grid` class a subclass of `Handler`.
2. Made `commit_grid` and `edit_types` methods of `Grid`.
3. Added `delete_table` function to `Handler.
4. Set default values for parameters of `Grid` (also swapped the order of lat and lon)

To make compatible, modify:
```
new_grid = Grid(table_name, top_left_lon, top_left_lat, rotation, crs_epsg, cell_size, nrows, ncols)
```
by
```
new_grid = Grid(table_name, top_left_lat, top_left_lon, rotation=rotation, crs_epsg=crs_epsg, cell_size=cell_size, nrows=nrows, ncols=ncols)
```

And
```
edit_types(grid_geo, new_types)
```
by
```
new_grid.edit_types(new_types)
```

And
```
commit_grid(table_name,grid_geo)
```
by
```
new_grid.commit_grid()
```

