### PR TITLE
list_tables_url now uses the chosen host rather than always remote.

### DIFF
--- a/brix/classes.py
+++ b/brix/classes.py
@@ -459,7 +459,7 @@ class Handler(Thread):
 		self.is_table : boolean
 			True if table exists.
 		'''
-		table_list_url = urljoin(self.remote_host,'api/tables/list')
+		table_list_url = urljoin(self.host,'api/tables/list')
 		r = self._get_url(table_list_url)
 		if r.status_code!=200:
 			raise NameError(f'Unable to retrieve list of tables: status code ={r.status_code}')

--- a/brix/functions.py
+++ b/brix/functions.py
@@ -61,7 +61,7 @@ def list_tables():
 	table_list: list
 		List of table names (strings).
 	'''
-	table_list_url = urljoin(Handler.remote_host,'api/tables/list')
+	table_list_url = urljoin(Handler.host,'api/tables/list')
 	r = requests.get(table_list_url)
 	if r.status_code!=200:
 		raise NameError(f'Unable to retrieve list of tables: status code ={r.status_code}')


### PR DESCRIPTION
Using local host was not working as it was still querying the list of tables from remote host. This fixes the issue.